### PR TITLE
Ensure new app instances don't get created on contentful_instances

### DIFF
--- a/lib/contentful_middleman/commands/contentful.rb
+++ b/lib/contentful_middleman/commands/contentful.rb
@@ -59,11 +59,13 @@ module Middleman
       end
 
       def contentful_instances
-        app = ::Middleman::Application.new do
+        app.contentful_instances
+      end
+
+      def app
+        @app ||= ::Middleman::Application.new do
           config[:mode] = :contentful
         end
-
-        app.contentful_instances
       end
 
       def create_import_task(instance)


### PR DESCRIPTION
This address a bug where every time the `contentful_instances` method would get called, a new Middleman::Application would get instantiated, the config would get re-run, and an additional ContentfulMiddleman instance would get added to ContentfulMiddleman.instances.

Essentially, *every* time the method was called the array of instances would grow by one. This result in duplicated files being built on the contentful task for me.

This PR address the issue by caching the Middleman Application behind an instance variable.