### PR TITLE
Fix ID Shadowing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Change Log
 ## Unreleased
+### Fixed
+* Fixed Entry ID fetch on import task when having an ID field in the Content Type[#77](https://github.com/contentful/contentful_middleman/issues/77)
 
 ## 1.3.1
 ### Fixed

--- a/lib/contentful_middleman/import_task.rb
+++ b/lib/contentful_middleman/import_task.rb
@@ -22,6 +22,15 @@ module ContentfulMiddleman
       @changed_local_data
     end
 
+    def entries
+      @entries ||= @contentful.entries
+    end
+
+    def file_name(content_type_name, entry)
+      entry_id = entry.sys.key?(:id) ? entry.sys[:id] : entry.id
+      File.join(@space_name, content_type_name, entry_id.to_s)
+    end
+
     private
     def local_data_files
       entries.map do |entry|
@@ -35,14 +44,8 @@ module ContentfulMiddleman
         content_type_mapper = content_type_mapper_class.new(entries, @contentful.options)
         content_type_mapper.map(context, entry)
 
-        entry_id = entry.sys.key?(:id) ? entry.sys[:id] : entry.id
-
-        LocalData::File.new(context.to_yaml, File.join(@space_name, content_type_name, entry_id.to_s))
+        LocalData::File.new(context.to_yaml, file_name(content_type_name, entry))
       end.compact
-    end
-
-    def entries
-      @entries ||= @contentful.entries
     end
   end
 end

--- a/lib/contentful_middleman/import_task.rb
+++ b/lib/contentful_middleman/import_task.rb
@@ -35,7 +35,9 @@ module ContentfulMiddleman
         content_type_mapper = content_type_mapper_class.new(entries, @contentful.options)
         content_type_mapper.map(context, entry)
 
-        LocalData::File.new(context.to_yaml, File.join(@space_name, content_type_name, entry.id))
+        entry_id = entry.sys.key?(:id) ? entry.sys[:id] : entry.id
+
+        LocalData::File.new(context.to_yaml, File.join(@space_name, content_type_name, entry_id.to_s))
       end.compact
     end
 

--- a/spec/contentful_middleman/import_task_spec.rb
+++ b/spec/contentful_middleman/import_task_spec.rb
@@ -6,9 +6,13 @@ class ClientDouble
   end
 end
 
+class EntryDouble
+end
+
 describe ContentfulMiddleman::ImportTask do
   let(:path) { File.expand_path(File.join(File.dirname(__FILE__), '..', 'fixtures', 'space_hash_fixtures')) }
-  subject { described_class.new 'foobar', {}, {}, ClientDouble.new }
+  let(:client) { ClientDouble.new }
+  subject { described_class.new 'foobar', {}, {}, client }
 
   describe 'instance methods' do
     before do
@@ -35,6 +39,23 @@ describe ContentfulMiddleman::ImportTask do
         subject.run
 
         expect(subject.changed_local_data?).to eq(true)
+      end
+    end
+
+    it '#entries' do
+      expect(subject.entries).to eq client.entries
+    end
+
+    describe '#file_name' do
+      it 'uses entry.sys[:id] over entry.id' do
+        entry = EntryDouble.new('foo', {}, {id: 'bar'})
+        client.entries << entry
+
+        expect(entry.id).not_to eq entry.sys[:id]
+        expect(entry.id).to eq 'bar'
+        expect(entry.sys[:id]).to eq 'foo'
+
+        expect(subject.file_name('baz', entry)).to eq File.join('foobar', 'baz', 'foo')
       end
     end
   end

--- a/spec/contentful_middleman/version_hash_spec.rb
+++ b/spec/contentful_middleman/version_hash_spec.rb
@@ -1,14 +1,5 @@
 require 'spec_helper'
 
-class EntryDouble
-  attr_reader :id, :updated_at
-
-  def initialize(id, updated_at)
-    @id = id
-    @updated_at = updated_at
-  end
-end
-
 describe ContentfulMiddleman::VersionHash do
   let(:path) { File.expand_path(File.join(File.dirname(__FILE__), '..', 'fixtures', 'space_hash_fixtures')) }
   describe 'class methods' do
@@ -32,7 +23,7 @@ describe ContentfulMiddleman::VersionHash do
     end
 
     describe '::write_for_space_with_entries' do
-      let(:entries) { [EntryDouble.new(1, '2015-11-25'), EntryDouble.new(2, '2015-11-25')] }
+      let(:entries) { [EntryDouble.new(1, {}, {}, '2015-11-25'), EntryDouble.new(2, {}, {}, '2015-11-25')] }
 
       before do
         described_class.source_root = path

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -64,3 +64,25 @@ class OptionsDouble
     end
   end
 end
+
+class EntryDouble
+  attr_reader :id, :sys, :fields
+
+  def initialize(id, sys_data = {}, fields = {}, updated_at = nil)
+    @id = id
+    sys_data[:id] = id
+    sys_data[:updated_at] = updated_at
+    @sys = sys_data
+    @fields = fields
+
+    fields.each do |k, v|
+      define_singleton_method k do
+        v
+      end
+    end
+  end
+
+  def updated_at
+    sys[:updated_at]
+  end
+end


### PR DESCRIPTION
Fixes #77 

Consider the following `config.rb` for testing:

```ruby
require 'contentful_middleman'

activate :contentful do |f|
  f.space = {test: '06iqaehcc4z6'}
  f.access_token = '6024aee307457689446d8e1c6a6979d7923b6246d9384cc832dbf80cc46c25c1'
  f.content_types = {shadow: 'shadow'}
end

set :css_dir, 'stylesheets'
set :js_dir, 'javascripts'
set :images_dir, 'images'

# Build-specific configuration
configure :build do
end

```