### PR TITLE
Make localize_entry localize nested entries and maintain hash base class.

### DIFF
--- a/lib/contentful_middleman/helpers.rb
+++ b/lib/contentful_middleman/helpers.rb
@@ -29,8 +29,8 @@ module ContentfulMiddleman
     end
 
     def localize_value(value, locale, fallback_locale='en-US')
-      value = value.fetch(locale) if value.respond_to?(:fetch) && value.respond_to?(:key) && value.key?(locale)
-      value = value.fetch(fallback_locale) if value.respond_to?(:fetch) && value.respond_to?(:key) && value.key?(fallback_locale)
+      value = value.fetch(locale) if value.respond_to?(:fetch) && value.respond_to?(:key?) && value.key?(locale)
+      value = value.fetch(fallback_locale) if value.respond_to?(:fetch) && value.respond_to?(:key?) && value.key?(fallback_locale)
 
       return localize_array(value, locale, fallback_locale) if value.is_a? ::Array
       return localize_entry(value, locale, fallback_locale) if value.is_a? ::Hash

--- a/lib/contentful_middleman/helpers.rb
+++ b/lib/contentful_middleman/helpers.rb
@@ -7,7 +7,8 @@ module ContentfulMiddleman
     end
 
     def localize_entry(entry, locale, fallback_locale='en-US')
-      localized_entry = {}
+      localized_entry = entry.class.new
+      localized_entry = {} unless localized_entry.is_a? ::Hash
       entry.each do |field, value|
         localized_entry[field] = localize(entry, field, locale, fallback_locale)
       end

--- a/lib/contentful_middleman/helpers.rb
+++ b/lib/contentful_middleman/helpers.rb
@@ -1,3 +1,4 @@
+require 'thor/core_ext/hash_with_indifferent_access'
 require 'contentful_middleman/tools/preview_proxy'
 
 module ContentfulMiddleman
@@ -7,8 +8,7 @@ module ContentfulMiddleman
     end
 
     def localize_entry(entry, locale, fallback_locale='en-US')
-      localized_entry = entry.class.new
-      localized_entry = {} unless localized_entry.is_a? ::Hash
+      localized_entry = ::Thor::CoreExt::HashWithIndifferentAccess.new
       entry.each do |field, value|
         localized_entry[field] = localize(entry, field, locale, fallback_locale)
       end

--- a/lib/contentful_middleman/helpers.rb
+++ b/lib/contentful_middleman/helpers.rb
@@ -28,10 +28,11 @@ module ContentfulMiddleman
     end
 
     def localize_value(value, locale, fallback_locale='en-US')
-      if value.respond_to? :fetch
-        return value.fetch(locale) if value.key? locale
-        return value.fetch(fallback_locale) if value.key? fallback_locale
-      end
+      value = value.fetch(locale) if value.respond_to?(:fetch) && value.respond_to?(:key) && value.key?(locale)
+      value = value.fetch(fallback_locale) if value.respond_to?(:fetch) && value.respond_to?(:key) && value.key?(fallback_locale)
+
+      return localize_array(value, locale, fallback_locale) if value.is_a? ::Array
+      return localize_entry(value, locale, fallback_locale) if value.is_a? ::Hash
       value
     end
 

--- a/spec/contentful_middleman/helpers_spec.rb
+++ b/spec/contentful_middleman/helpers_spec.rb
@@ -128,30 +128,30 @@ describe ContentfulMiddleman::Helpers do
 
       it '#localize_entry' do
         expect(subject.localize_entry(entry, 'es')).to eq({
-          _meta: { id: 'foo' },
-          value_field: 'foo',
-          array_field: ['foobar'],
-          nested_array: [
+          '_meta' => { 'id' => 'foo' },
+          'value_field' => 'foo',
+          'array_field' => ['foobar'],
+          'nested_array' => [
             {
-              id: 'foo',
-              _meta: {
-                id: 'foo'
+              'id' => 'foo',
+              '_meta' => {
+                'id' => 'foo'
               },
-              name: 'foo'
+              'name' => 'foo'
             }, {
-              id: 'foo',
-              _meta: {
-                id: 'foo'
+              'id' => 'foo',
+              '_meta' => {
+                'id' => 'foo'
               },
-              name: 'foo'
+              'name' => 'foo'
             }
           ],
-          nested_hash: {
-            id: 'foo',
-            _meta: {
-              id: 'foo'
+          'nested_hash' => {
+            'id' => 'foo',
+            '_meta' => {
+              'id' => 'foo'
             },
-            name: 'foo'
+            'name' => 'foo'
           }
         })
       end

--- a/spec/contentful_middleman/helpers_spec.rb
+++ b/spec/contentful_middleman/helpers_spec.rb
@@ -23,7 +23,7 @@ describe ContentfulMiddleman::Helpers do
           'en-US' => 'baz'
         }
       ],
-      nested_field: {
+      nested_array: {
         'en-US' => [
           {
             id: 'foo',
@@ -45,6 +45,18 @@ describe ContentfulMiddleman::Helpers do
             },
           }
         ]
+      },
+      nested_hash: {
+        'en-US' => {
+          id: 'foo',
+          _meta: {
+            id: 'foo',
+          },
+          name: {
+            'es' => 'foo',
+            'en-US' => 'bar'
+          }
+        }
       }
     }
   end
@@ -119,7 +131,7 @@ describe ContentfulMiddleman::Helpers do
           _meta: { id: 'foo' },
           value_field: 'foo',
           array_field: ['foobar'],
-          nested_field: [
+          nested_array: [
             {
               id: 'foo',
               _meta: {
@@ -133,7 +145,14 @@ describe ContentfulMiddleman::Helpers do
               },
               name: 'foo',
             }
-          ]
+          ],
+          nested_hash: {
+            id: 'foo',
+            _meta: {
+              id: 'foo',
+            },
+            name: 'foo'
+          }
         })
       end
     end

--- a/spec/contentful_middleman/helpers_spec.rb
+++ b/spec/contentful_middleman/helpers_spec.rb
@@ -11,7 +11,7 @@ describe ContentfulMiddleman::Helpers do
   let(:entry) do
     {
       _meta: {
-        id: 'foo',
+        id: 'foo'
       },
       value_field: {
         'es' => 'foo',
@@ -28,7 +28,7 @@ describe ContentfulMiddleman::Helpers do
           {
             id: 'foo',
             _meta: {
-              id: 'foo',
+              id: 'foo'
             },
             name: {
               'es' => 'foo',
@@ -37,7 +37,7 @@ describe ContentfulMiddleman::Helpers do
           }, {
             id: 'foo',
             _meta: {
-              id: 'foo',
+              id: 'foo'
             },
             name: {
               'en-NZ' => 'bar',
@@ -50,7 +50,7 @@ describe ContentfulMiddleman::Helpers do
         'en-US' => {
           id: 'foo',
           _meta: {
-            id: 'foo',
+            id: 'foo'
           },
           name: {
             'es' => 'foo',
@@ -135,21 +135,21 @@ describe ContentfulMiddleman::Helpers do
             {
               id: 'foo',
               _meta: {
-                id: 'foo',
+                id: 'foo'
               },
               name: 'foo'
             }, {
               id: 'foo',
               _meta: {
-                id: 'foo',
+                id: 'foo'
               },
-              name: 'foo',
+              name: 'foo'
             }
           ],
           nested_hash: {
             id: 'foo',
             _meta: {
-              id: 'foo',
+              id: 'foo'
             },
             name: 'foo'
           }

--- a/spec/contentful_middleman/helpers_spec.rb
+++ b/spec/contentful_middleman/helpers_spec.rb
@@ -11,7 +11,7 @@ describe ContentfulMiddleman::Helpers do
   let(:entry) do
     {
       _meta: {
-        id: 'foo'
+        id: 'foo',
       },
       value_field: {
         'es' => 'foo',
@@ -22,7 +22,30 @@ describe ContentfulMiddleman::Helpers do
           'es' => 'foobar',
           'en-US' => 'baz'
         }
-      ]
+      ],
+      nested_field: {
+        'en-US' => [
+          {
+            id: 'foo',
+            _meta: {
+              id: 'foo',
+            },
+            name: {
+              'es' => 'foo',
+              'en-US' => 'bar'
+            }
+          }, {
+            id: 'foo',
+            _meta: {
+              id: 'foo',
+            },
+            name: {
+              'en-NZ' => 'bar',
+              'en-US' => 'foo'
+            },
+          }
+        ]
+      }
     }
   end
 
@@ -95,7 +118,22 @@ describe ContentfulMiddleman::Helpers do
         expect(subject.localize_entry(entry, 'es')).to eq({
           _meta: { id: 'foo' },
           value_field: 'foo',
-          array_field: ['foobar']
+          array_field: ['foobar'],
+          nested_field: [
+            {
+              id: 'foo',
+              _meta: {
+                id: 'foo',
+              },
+              name: 'foo'
+            }, {
+              id: 'foo',
+              _meta: {
+                id: 'foo',
+              },
+              name: 'foo',
+            }
+          ]
         })
       end
     end

--- a/spec/contentful_middleman/helpers_spec.rb
+++ b/spec/contentful_middleman/helpers_spec.rb
@@ -127,7 +127,8 @@ describe ContentfulMiddleman::Helpers do
       end
 
       it '#localize_entry' do
-        expect(subject.localize_entry(entry, 'es')).to eq({
+        localized_entry = subject.localize_entry(entry, 'es')
+        expect(localized_entry).to eq({
           '_meta' => { 'id' => 'foo' },
           'value_field' => 'foo',
           'array_field' => ['foobar'],
@@ -154,6 +155,10 @@ describe ContentfulMiddleman::Helpers do
             'name' => 'foo'
           }
         })
+
+        expect(localized_entry[:_meta]).to eq({ 'id' => 'foo' })
+        expect(localized_entry[:nested_array][0][:id]).to eq('foo')
+        expect(localized_entry[:nested_hash][:id]).to eq('foo')
       end
     end
 


### PR DESCRIPTION
Aims to fix my issue #130.  Seems to work fine for my use case.

Ruby isn't really my language, so something like `localized_entry = entry.class.new` (to create a new instance of the same type of the entry) may be a horrible idea..