### PR TITLE
Document custom mapper initializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,21 @@ The default mapper will map fields, assets and linked entries.
 
 ### Custom mappers
 
-You can create your own mappers if you need so. The only requirement for a class to behave as a
-mapper is to have a `map(context, entry)` instance method. This method will take as parameters:
+You can create your own mappers if you need so. The only requirements for a class to behave as a
+mapper are an initializer and a `map(context, entry)` instance method.
+
+The initializer takes two parameters:
+
+  * A `Contentful::Array` of all entries for the current content model
+  * A `Middleman::Configuration::ConfigurationManager` object containing the Contentful configuration options set in `config.rb`
+
+[See BackrefMapper](https://github.com/contentful/contentful_middleman/blob/master/examples/mappers/backref.rb)
+for an example use of entries.
+
+[See the Base mapper](https://github.com/contentful/contentful_middleman/blob/master/lib/contentful_middleman/mappers/base.rb)
+for an example use of options.
+
+The `map` method takes two parameters:
 
   * A context object. All properties set on this object will be written to the yaml file
   * An entry
@@ -85,6 +98,11 @@ Following is an example of such custom mapper:
 
 ```ruby
 class MyAwesomeMapper
+  def initialize(entries, options)
+    @entries = entries
+    @options = options
+  end
+
   def map(context, entry)
     context.slug = entry.title.parameterize
     #... more transformations


### PR DESCRIPTION
Because `ImportTask#local_data_files` [always initializes new mappers with two arguments](https://github.com/contentful/contentful_middleman/blob/master/lib/contentful_middleman/import_task.rb#L44) (entries and Contentful options), custom mappers that do not inherit from `ContentfulMiddleman::Mapper::Base` also require an initializer that takes those two arguments.

This PR updates the custom mapper documentation to explain that requirement.

Or, there's probably a case to be made for not wanting to require the initializer, especially since many mappers might not use the arguments at all. If that's the case let me know.