### PR TITLE
Add support to choose environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ To configure the extension, add the following configuration block to Middleman's
 ```ruby
 activate :contentful do |f|
   f.space         = SPACE
+  f.env           = CONTENTFUL_ENV
   f.access_token  = ACCESS_TOKEN
   f.cda_query     = QUERY
   f.content_types = CONTENT_TYPES_MAPPINGS
@@ -53,6 +54,7 @@ end
 Parameter                | Description
 ----------               | ------------
 space                    | Hash with an user choosen name for the space as key and the space id as value.
+env                      | Contentful Space's Environment. (default: master)
 access_token             | Contentful Delivery API access token.
 cda_query                | Hash describing query configuration. See [contentful.rb](https://github.com/contentful/contentful.rb) for more info (look for filter options there). Note that by default only 100 entries will be fetched, this can be configured to up to 1000 entries using the `limit` option. Example: `f.cda_query = { limit: 1000 }`.
 client_options           | Hash describing client configuration. See [contentful.rb](https://github.com/contentful/contentful.rb#client-configuration-options) for more info. This option should commonly be used to change Rate Limit Management, Include Resolution, Logging and Proxies.

--- a/lib/contentful_middleman/core.rb
+++ b/lib/contentful_middleman/core.rb
@@ -19,6 +19,9 @@ module ContentfulMiddleman
     option :space, nil,
       'The Contentful Space ID and name'
 
+    option :env, 'master',
+      "The Contentful Space's Environment (default: master)"
+
     option :access_token, nil,
       'The Contentful Content Delivery API access token'
 

--- a/lib/contentful_middleman/instance.rb
+++ b/lib/contentful_middleman/instance.rb
@@ -64,6 +64,7 @@ module ContentfulMiddleman
       client_options = {
           access_token:     options.access_token,
           space:            options.space.fetch(:id),
+          environment:      options.env,
           dynamic_entries:  :auto,
           raise_errors:     true,
           default_locale:   options.default_locale,

--- a/spec/contentful_middleman/core_spec.rb
+++ b/spec/contentful_middleman/core_spec.rb
@@ -14,6 +14,7 @@ describe ContentfulMiddleman::Core do
   describe 'options' do
     it 'defaults' do
       expect(options.space).to eq(nil)
+      expect(options.env).to eq('master')
       expect(options.access_token).to eq(nil)
       expect(options.cda_query).to eq({})
       expect(options.content_types).to eq({})


### PR DESCRIPTION
Contentful now has the ability to work with multiple environments within a single space. This adds the ability to provide that option to the client, otherwise it falls back to `master`, which is Contentful's default environment.

I don't have access to your test space, so I've only added a spec for the default value. I've tested manually and it works fine, following [contentful.rb's configuration options](https://github.com/contentful/contentful.rb#configuration).